### PR TITLE
fix auth/validate route

### DIFF
--- a/app/src/services/auth-service.js
+++ b/app/src/services/auth-service.js
@@ -4,7 +4,7 @@ export default function authService(token, $http, apiUrl) {
     const current = token.get();
     if(current) {
         $http
-      .post(`${apiUrl}/auth/verify`)
+      .post(`${apiUrl}/auth/validate`)
       .catch(() => token.remove());
     } 
 


### PR DESCRIPTION
Token was being removed on refresh because the catch was being hit on the auth/validate route. The auth-service had a post request to auth/verify, and the server route was auth/validate. Changed the service to match the route.